### PR TITLE
Feat/align with blueprints

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,23 @@
+{
+    "arrowParens": "always",
+    "bracketSameLine": false,
+    "objectWrap": "preserve",
+    "bracketSpacing": true,
+    "semi": true,
+    "experimentalOperatorPosition": "end",
+    "experimentalTernaries": false,
+    "singleQuote": true,
+    "jsxSingleQuote": false,
+    "quoteProps": "as-needed",
+    "trailingComma": "all",
+    "singleAttributePerLine": false,
+    "htmlWhitespaceSensitivity": "css",
+    "vueIndentScriptAndStyle": false,
+    "proseWrap": "preserve",
+    "insertPragma": false,
+    "printWidth": 80,
+    "requirePragma": false,
+    "tabWidth": 2,
+    "useTabs": true,
+    "embeddedLanguageFormatting": "auto"
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install
 In the root of the project, create a `.env` file to store your Storyblok access tokens:
 
 ```sh
-VITE_STORYBLOK_DELIVERY_API_TOKEN=<REPLACE_WITH_YOUR_TOKEN>
+STORYBLOK_DELIVERY_API_TOKEN=<REPLACE_WITH_YOUR_TOKEN>
 ```
 
 > [!IMPORTANT]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "build"

--- a/src/lib/Page.svelte
+++ b/src/lib/Page.svelte
@@ -1,11 +1,13 @@
 <script>
-  import { StoryblokComponent, storyblokEditable } from "@storyblok/svelte";
+	import { StoryblokComponent, storyblokEditable } from '@storyblok/svelte';
 
-  export let blok;
+	export let blok;
 </script>
 
-<main class="page" use:storyblokEditable={blok}>
-  {#each blok.body as blok}
-    <StoryblokComponent {blok} />
-  {/each}
-</main>
+{#key blok}
+	<main class="page" use:storyblokEditable={blok}>
+		{#each blok.body as blok}
+			<StoryblokComponent {blok} />
+		{/each}
+	</main>
+{/key}

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -6,13 +6,13 @@ import Page from '$lib/Page.svelte';
 
 export async function load(params) {
 	storyblokInit({
-		accessToken: import.meta.env.VITE_STORYBLOK_DELIVERY_API_TOKEN,
+		accessToken: import.meta.env.STORYBLOK_DELIVERY_API_TOKEN,
 		apiOptions: {
-			/** Set the correct region for your space. Learn more: https://www.storyblok.com/docs/packages/storyblok-js */
+			/** Set the correct region for your space. Learn more: https://www.storyblok.com/docs/packages/storyblok-js#example-region-parameter */
 			region: 'eu',
 			/** The following code is only required when creating a Storyblok space directly via the Blueprints feature. */
-			endpoint: import.meta.env.VITE_STORYBLOK_API_BASE_URL
-				? `${new URL(import.meta.env.VITE_STORYBLOK_API_BASE_URL).origin}/v2`
+			endpoint: import.meta.env.STORYBLOK_API_BASE_URL
+				? `${new URL(import.meta.env.STORYBLOK_API_BASE_URL).origin}/v2`
 				: undefined,
 		},
 		use: [apiPlugin],

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "buildCommand": "npm run build",
+    "outputDirectory": "build",
+    "framework": "sveltekit",
+    "trailingSlash": false
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,19 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import mkcert from 'vite-plugin-mkcert';
 
-export default defineConfig({
-	plugins: [sveltekit(), mkcert()],
+// https://vite.dev/config/
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, process.cwd(), '');
+	return {
+		plugins: [sveltekit(), mkcert()],
+		define: {
+			'import.meta.env.STORYBLOK_DELIVERY_API_TOKEN': JSON.stringify(
+				env.STORYBLOK_DELIVERY_API_TOKEN,
+			),
+			'import.meta.env.STORYBLOK_API_BASE_URL': JSON.stringify(
+				env.STORYBLOK_API_BASE_URL,
+			),
+		},
+	};
 });


### PR DESCRIPTION
This PR aligns the env variable naming with other blueprints by renaming `VITE_STORYBLOK_API_BASE_URL` to `STORYBLOK_API_BASE_URL` and updates the README accordingly.

* Fixed a reactivity issue in `Page.svelte` by wrapping it with `{#key}`.
* Added `vercel.json` and `netlify.toml` config files for deployment support on Vercel and Netlify.
